### PR TITLE
Set UID,fsGroup and Linux options to cassandra RC's

### DIFF
--- a/roles/openshift_metrics/tasks/install_cassandra.yaml
+++ b/roles/openshift_metrics/tasks/install_cassandra.yaml
@@ -27,6 +27,10 @@
     master: "{{ (item == '1')|string|lower }}"
     replica_count: "{{cassandra_replica_count.results[item|int - 1].stdout}}"
     node_selector: "{{openshift_metrics_cassandra_nodeselector | default('') }}"
+    fsgroup: "{{ openshift_metrics_namespace_fsgroup | default(false) }}"
+    run_as_uid: "{{ openshift_metrics_namespace_uid | default(false) }}"
+    selinux_level: "{{ openshift_metrics_namespace_selinux | default(false) }}"
+
   with_sequence: count={{ openshift_metrics_cassandra_replicas }}
   changed_when: false
 

--- a/roles/openshift_metrics/tasks/pre_install.yaml
+++ b/roles/openshift_metrics/tasks/pre_install.yaml
@@ -19,3 +19,55 @@
     get secrets -o name
   register: metrics_secrets
   changed_when: false
+
+- name: Get namespace object
+  oc_obj:
+    state: list
+    kind: project
+    name: "{{ openshift_metrics_project }}"
+    namespace: "{{ openshift_metrics_project }}"
+  register: openshift_metrics_namespace_object
+
+- name: Get namespace annotations
+  set_fact:
+    openshift_metrics_namespace_annotations: >
+      {{ openshift_metrics_namespace_object.results.results[0].metadata.annotations }}
+  when:
+    - openshift_metrics_namespace_object is defined
+    - openshift_metrics_namespace_object.results is defined
+    - openshift_metrics_namespace_object.results.results is defined
+    - openshift_metrics_namespace_object.results.results[0] is defined
+    - openshift_metrics_namespace_object.results.results[0].metadata is defined
+
+- debug:
+    var: openshift_metrics_namespace_annotations
+
+- name: Get namespace fsGroup
+  set_fact:
+    openshift_metrics_namespace_fsgroup: >
+      {{ openshift_metrics_namespace_annotations['openshift.io/sa.scc.supplemental-groups'].split("/")[0] | trim }}
+  when:
+    - openshift_metrics_namespace_annotations is defined
+    - openshift_metrics_namespace_annotations['openshift.io/sa.scc.supplemental-groups'] is defined
+
+- name: Get namespace userID
+  set_fact:
+    openshift_metrics_namespace_uid: >
+      {{ openshift_metrics_namespace_annotations['openshift.io/sa.scc.uid-range'].split("/")[0] | trim }}
+  when:
+    - openshift_metrics_namespace_annotations is defined
+    - openshift_metrics_namespace_annotations['openshift.io/sa.scc.uid-range'] is defined
+
+- name: Get namespace seLinuxOptions
+  set_fact:
+    openshift_metrics_namespace_selinux: >
+      {{ openshift_metrics_namespace_annotations['openshift.io/sa.scc.mcs'] | trim }}
+  when:
+    - openshift_metrics_namespace_annotations is defined
+    - openshift_metrics_namespace_annotations['openshift.io/sa.scc.mcs'] is defined
+
+- debug:
+    var: openshift_metrics_namespace_fsgroup
+
+- debug:
+    var: openshift_metrics_namespace_uid

--- a/roles/openshift_metrics/templates/hawkular_cassandra_rc.j2
+++ b/roles/openshift_metrics/templates/hawkular_cassandra_rc.j2
@@ -20,6 +20,13 @@ spec:
     spec:
       serviceAccount: cassandra
       securityContext:
+{% if fsgroup  %}
+        fsGroup: {{ fsgroup }}
+{% endif %}
+{% if selinux_level %}
+        seLinuxOptions:
+          level: {{ selinux_level }}
+{% endif %}
         supplementalGroups:
         - {{openshift_metrics_cassandra_storage_group}}
 {% if node_selector is iterable and node_selector | length > 0 %}
@@ -82,6 +89,10 @@ spec:
           mountPath: "/cassandra_data"
         - name: hawkular-cassandra-certs
           mountPath: "/hawkular-cassandra-certs"
+{% if run_as_uid  %}
+        securityContext:
+          runAsUser: {{ run_as_uid }}
+{% endif %}
 {% if ((openshift_metrics_cassandra_limits_cpu is defined and openshift_metrics_cassandra_limits_cpu is not none)
    or (openshift_metrics_cassandra_limits_memory is defined and openshift_metrics_cassandra_limits_memory is not none)
    or (openshift_metrics_cassandra_requests_cpu is defined and openshift_metrics_cassandra_requests_cpu is not none)


### PR DESCRIPTION
@jsanda this is the new fix for the problem of namespaces. I haven't tested it on OCP 3.10 but please review and leave your comments.